### PR TITLE
REP-1106 Enable project-specific URN OAI set

### DIFF
--- a/src/main/resources/config/reposis_zmo/mycore.properties
+++ b/src/main/resources/config/reposis_zmo/mycore.properties
@@ -105,6 +105,10 @@ MCR.OAIDataProvider.OAI2.MapSetToQuery.xmetadissplus=derCount:[1 TO *] AND NOT(m
 MCR.OAIDataProvider.OAI2.Sets.xmetadissplus.URI=webapp:oai/set_xmetadissplus.xml
 MCR.OAIDataProvider.OAI2.Sets=doc-type,open_access,openaire,driver,ec_fundedresources,GENRE,ddc,xmetadissplus
 
+# Enable the URN set configured by reposis_common.
+MCR.OAIDataProvider.OAI2.Sets=%MCR.OAIDataProvider.OAI2.Sets%,urn
+MCR.OAIDataProvider.OAI2.Sets.urn.Query=mods.identifier:urn* AND mods.identifier:*0307-*
+
 # friendly OAI interfaces
 MCR.OAIDataProvider.OAI2.Friends.LeibnitzOpen=https://leibnizopen.de/oaip/oai
 MCR.OAIDataProvider.OAI2.Friends.BaseSearch=http://oai.base-search.net/oai


### PR DESCRIPTION
## Changes

- enable the `urn` OAI set provided by `reposis_common`
- override the shared query with the configured `urn:nbn:de:0307-` namespace

```properties
MCR.OAIDataProvider.OAI2.Sets.urn.Query=mods.identifier:urn* AND mods.identifier:*0307-*
```

Production currently has no records matching this configured namespace. The PR remains a draft pending clarification.

Ticket: REP-1106